### PR TITLE
package.yaml: Ensure PCRE2_STATIC=1 is defined

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -64,6 +64,7 @@ library:
   - src/c/pcre2/src/pcre2_xclass.c
   ghc-options:
   - -optc=-DPCRE2_CODE_UNIT_WIDTH=16
+  - -optc=-DPCRE2_STATIC=1
   - -optc=-Wno-discarded-qualifiers
   - -optc=-Wno-incompatible-pointer-types
   cc-options:

--- a/pcre2.cabal
+++ b/pcre2.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b662a93fe9a757f35a7bbdce43213dd4fdac16545bf7ab54f3b571d13684d3d7
+-- hash: 0291a918bec29e796a44b6eb8d49372cc7610f8fd7895f58b7c4d49a255c804e
 
 name:           pcre2
 version:        1.0.0
@@ -110,7 +110,7 @@ library
       Paths_pcre2
   hs-source-dirs:
       src/hs
-  ghc-options: -optc=-DPCRE2_CODE_UNIT_WIDTH=16 -optc=-Wno-discarded-qualifiers -optc=-Wno-incompatible-pointer-types
+  ghc-options: -optc=-DPCRE2_CODE_UNIT_WIDTH=16 -optc=-DPCRE2_STATIC=1 -optc=-Wno-discarded-qualifiers -optc=-Wno-incompatible-pointer-types
   cc-options: -DHAVE_CONFIG_H -DPCRE2_CODE_UNIT_WIDTH=16
   include-dirs:
       src/c


### PR DESCRIPTION
When the pcre2 library is compiled, `config.h` gets included, which
defines `PCRE2_STATIC=1`. However, when compiling the test suite,
`config.h` is not loaded, `PCRE2_STATIC` is undefined, so `pcre2.h`
defaults to specifying the `__declspec(dllimport)` attribute on all the
public API functions. It'll try to link against `__imp_<symbol>`, which
won't exist because pcre2 is a static library.

Fixes: #1

Signed-off-by: Andrew Gunnerson <chillermillerlong@hotmail.com>