### PR TITLE
add CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  cabal:
+    name: Cabal CI
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        ghc:
+          - 8.6.5
+          - 8.8.4
+          - 8.10.2
+        # 8.10.2 is broken on Windows, but there is a patched version
+        exclude:
+          - os: windows-latest
+            ghc: 8.10.2
+        include:
+          - os: windows-latest
+            ghc: 8.10.2.2
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: haskell/actions/setup@main
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - name: Build library
+        run: cabal build
+      - name: Run tests
+        run: cabal test --test-show-details=direct
+      - name: Build benchmarks
+        run: cabal build --enable-benchmarks
+        # pcre (via pcre-light) not available on windows (without further setup)
+        if: runner.os != 'Windows'
+      - name: Build documentation
+        run: cabal haddock
+  stack:
+    name: Stack CI
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: haskell/actions/setup@main
+        with:
+          enable-stack: true
+      - name: Build library
+        run: stack build
+      - name: Run tests
+        run: stack test
+      - name: Build benchmarks
+        run: stack bench --no-run-benchmarks
+        # pcre (via pcre-light) not available on windows (without further setup)
+        if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,18 @@ jobs:
         with:
           submodules: true
       - uses: haskell/actions/setup@main
+        id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
+      - name: Freeze build
+        run: cabal freeze
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            cabal-${{ runner.os }}-${{ matrix.ghc }}-
+
       - name: Build library
         run: cabal build
       - name: Run tests
@@ -55,11 +65,9 @@ jobs:
       - uses: haskell/actions/setup@main
         with:
           enable-stack: true
+          stack-no-global: true
+
       - name: Build library
         run: stack build
       - name: Run tests
         run: stack test
-      - name: Build benchmarks
-        run: stack bench --no-run-benchmarks
-        # pcre (via pcre-light) not available on windows (without further setup)
-        if: runner.os != 'Windows'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 *~
+dist-newstyle/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pcre2
 
+![CI](https://github.com/sjshuck/hs-pcre2/workflows/CI/badge.svg)
+[![Hackage](https://img.shields.io/hackage/v/pcre2)](https://hackage.haskell.org/package/pcre2)
+
 Regular expressions for Haskell.  
 https://hackage.haskell.org/package/pcre2
 
@@ -55,7 +58,6 @@ forMOf kv'd file $ execStateT $ do
 * Many performance optimizations.  Currently we are 2&ndash;3&times; slower
   than other libraries doing everything (a few &mu;s).
 * Make use of DFA and JIT compilation.
-* Establish automated builds.
 * Improve PCRE2 C compile time.
 * PCRE2 10.36 is out already.
 


### PR DESCRIPTION
 - Benchmarks are only built, not executed.
 - [`dependabot.yml`](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot) will create PRs to update the versions of the actions in `ci.yml`.
 - [`actions/setup-haskell`](https://github.com/actions/setup-haskell)  will soon be [deprecated](https://github.com/actions/setup-haskell/pull/56), but the new [haskell/actions/setup](https://github.com/haskell/actions/tree/main/setup) did not release a tagged version yet, so we depend on `@main` for now.
