### PR TITLE
update to haskell/actions/setup@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,12 @@ jobs:
           - 8.6.5
           - 8.8.4
           - 8.10.2
-        # 8.10.2 is broken on Windows, but there is a patched version
-        exclude:
-          - os: windows-latest
-            ghc: 8.10.2
-        include:
-          - os: windows-latest
-            ghc: 8.10.2.2
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: haskell/actions/setup@main
+      - uses: haskell/actions/setup@v1
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -62,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: haskell/actions/setup@main
+      - uses: haskell/actions/setup@v1
         with:
           enable-stack: true
           stack-no-global: true


### PR DESCRIPTION
as announced in #6

in particular, the workaround for GHC 8.10.2 on Windows is no longer necessary