### PR TITLE
Implement global matching

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog and Acknowledgements
 
+## 1.1.0
+* Added global matching.
+    * New functions `matchAll`, `matchAllOpt`, `capturesAll`, `capturesAllOpt`.
+    * Changed all traversals from affine to non-affine.
+* Changed `capturesOptA` to `capturesAOpt` for naming consistency.
+
 ## 1.0.2
 * Fixed [#4](https://github.com/sjshuck/pcre2/4), where multiple named captures
   were not type-indexed correctly.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ forMOf kv'd file $ execStateT $ do
   10.35), with a complete, exposed Haskell binding.
 
 ## TODO
-* Global matching.  (We already have global substitution.)
 * Many performance optimizations.  Currently we are 2&ndash;3&times; slower than
   other libraries doing most things (order of a few &mu;s).
 * Make use of DFA and JIT compilation.

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -68,12 +68,21 @@ main = defaultMain [
             in capture @"bar" cs],
 
     bgroup "substitutions" [
-        bench "PCRE2-native" $ flip nf textSubject $
-            sub (Text.pack "(?<=foo )bar(?= baz)") (Text.pack "quux"),
+        bgroup "single" [
+            bench "PCRE2-native" $ flip nf textSubject $
+                sub (Text.pack "(?<=foo )bar(?= baz)") (Text.pack "quux"),
 
-        let quux = Text.pack "quux"
-        in bench "lens-powered" $ flip nf textSubject $
-            set ([_regex|foo (bar) baz|] . _capture @1) quux]]
+            let quux = Text.pack "quux"
+            in bench "lens-powered" $ flip nf textSubject $
+                set ([_regex|foo (bar) baz|] . _capture @1) quux],
+
+        let fruit = Text.pack "apples and bananas"
+        in bgroup "multiple" [
+            let a2o = gsub (Text.pack "a") (Text.pack "o")
+            in bench "PCRE2-native" $ nf a2o fruit,
+
+            let a2o = set [_regex|a|] (Text.pack "o")
+            in bench "lens-powered" $ nf a2o fruit]]]
 
 stringPattern = "foo (bar) baz"
 stringSubject = "foo bar baz"

--- a/package.yaml
+++ b/package.yaml
@@ -1,9 +1,9 @@
 name:                pcre2
-version:             1.0.2
+version:             1.1.0
 github:              "sjshuck/hs-pcre2"
 license:             Apache-2.0
 license-file:        LICENSE # [LICENSE, src/c/pcre2/LICENCE] doesn't work with stack sdist
-author:              "Shlomo Shuck"
+author:              "Shlomo Shuck and contributors"
 maintainer:          "stevenjshuck@gmail.com"
 copyright:           "2020 Shlomo Shuck"
 
@@ -27,6 +27,7 @@ dependencies:
 - mtl
 - template-haskell
 - text
+- transformers
 
 library:
   source-dirs: src/hs

--- a/pcre2.cabal
+++ b/pcre2.cabal
@@ -4,16 +4,16 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9e2fa347c266eb48c8d78b48cae7cbadf7ea4bf1414ecafc9fbaeb5e2a7c492c
+-- hash: 0a7a573e61659cfbca9092c36ae2549d63b0c6745b4bc3953f29dfc97aebd1b6
 
 name:           pcre2
-version:        1.0.2
+version:        1.1.0
 synopsis:       Regular expressions via the PCRE2 C library (included)
 description:    Please see the README on GitHub at <https://github.com/sjshuck/hs-pcre2>
 category:       Text
 homepage:       https://github.com/sjshuck/hs-pcre2#readme
 bug-reports:    https://github.com/sjshuck/hs-pcre2/issues
-author:         Shlomo Shuck
+author:         Shlomo Shuck and contributors
 maintainer:     stevenjshuck@gmail.com
 copyright:      2020 Shlomo Shuck
 license:        Apache-2.0
@@ -149,6 +149,7 @@ library
     , mtl
     , template-haskell
     , text
+    , transformers
   default-language: Haskell2010
 
 test-suite pcre2-test
@@ -168,6 +169,7 @@ test-suite pcre2-test
     , pcre2
     , template-haskell
     , text
+    , transformers
   default-language: Haskell2010
 
 benchmark pcre2-benchmarks
@@ -189,4 +191,5 @@ benchmark pcre2-benchmarks
     , regex-pcre-builtin
     , template-haskell
     , text
+    , transformers
   default-language: Haskell2010

--- a/src/hs/Text/Regex/Pcre2.hs
+++ b/src/hs/Text/Regex/Pcre2.hs
@@ -138,12 +138,16 @@ module Text.Regex.Pcre2 (
     -- ** Basic matching functions
     match,
     matchOpt,
+    matchAll,
+    matchAllOpt,
     matches,
     matchesOpt,
     captures,
     capturesOpt,
     capturesA,
-    capturesOptA,
+    capturesAOpt,
+    capturesAll,
+    capturesAllOpt,
 
     -- ** PCRE2-native substitution
     sub,
@@ -176,7 +180,7 @@ module Text.Regex.Pcre2 (
     -- > _nee :: Traversal' Text Text
     -- > _nee = _match "(?i)\\bnee\\b"
     --
-    -- In addition to getting results, they support substitution through
+    -- In addition to getting results, they support global substitution through
     -- setting; more generally, they can accrete effects while performing
     -- replacements.
     --
@@ -185,12 +189,6 @@ module Text.Regex.Pcre2 (
     -- "NEE"
     -- NOO
     -- "We are the knights who say...NOO!"
-    -- >>>
-    --
-    -- The optic interface signals match failure by not targeting anything.
-    --
-    -- >>> promptNee "Shhhhh"
-    -- "Shhhhh"
     -- >>>
     --
     -- In general these traversals are not law-abiding.

--- a/src/hs/Text/Regex/Pcre2/Internal.hs
+++ b/src/hs/Text/Regex/Pcre2/Internal.hs
@@ -1082,8 +1082,8 @@ getOvecEntriesAt ns matchData = withForeignPtr matchData $ \matchDataPtr -> do
 withMatcher :: (Matcher -> a) -> Option -> Text -> a
 withMatcher f option patt = f $ unsafePerformIO $ assembleMatcher option patt
 
--- | Match a pattern to a subject and return a list of captures, or @[]@ if no
--- match.
+-- | Match a pattern to a subject once and return a list of captures, or @[]@ if
+-- no match.
 captures :: Text -> Text -> [Text]
 captures = capturesOpt mempty
 
@@ -1091,9 +1091,9 @@ captures = capturesOpt mempty
 capturesOpt :: Option -> Text -> Text -> [Text]
 capturesOpt option patt = view $ _capturesOpt option patt . to NE.toList
 
--- | Match a pattern to a subject and return a non-empty list of captures in an
--- `Alternative`, or `empty` if no match.  The non-empty list constructor `:|`
--- serves as a cue to differentiate the 0th capture from the others:
+-- | Match a pattern to a subject once and return a non-empty list of captures
+-- in an `Alternative`, or `empty` if no match.  The non-empty list constructor
+-- `:|` serves as a cue to differentiate the 0th capture from the others:
 --
 -- > let parseDate = capturesA "(\\d{4})-(\\d{2})-(\\d{2})"
 -- > in case parseDate "submitted 2020-10-20" of
@@ -1104,7 +1104,7 @@ capturesA = capturesAOpt mempty
 
 -- | @capturesAOpt mempty = capturesA@
 --
--- @since 1.2.0
+-- @since 1.1.0
 capturesAOpt :: (Alternative f) => Option -> Text -> Text -> f (NonEmpty Text)
 capturesAOpt option patt = toAlternativeOf $ _capturesOpt option patt
 
@@ -1112,13 +1112,13 @@ capturesAOpt option patt = toAlternativeOf $ _capturesOpt option patt
 -- of captures corresponding to every non-overlapping place in the subject the
 -- pattern matched.
 --
--- @since 1.2.0
+-- @since 1.1.0
 capturesAll :: Text -> Text -> [NonEmpty Text]
 capturesAll = capturesAllOpt mempty
 
 -- | @capturesAllOpt mempty = capturesAll@
 --
--- @since 1.2.0
+-- @since 1.1.0
 capturesAllOpt :: Option -> Text -> Text -> [NonEmpty Text]
 capturesAllOpt option patt = toListOf $ _capturesOpt option patt
 
@@ -1130,7 +1130,7 @@ matches = matchesOpt mempty
 matchesOpt :: Option -> Text -> Text -> Bool
 matchesOpt = withMatcher $ \matcher -> has $ _capturesInternal matcher []
 
--- | Match a pattern to a subject and return the portion that matched in an
+-- | Match a pattern to a subject once and return the portion that matched in an
 -- `Alternative`, or `empty` if no match.
 match :: (Alternative f) => Text -> Text -> f Text
 match = matchOpt mempty
@@ -1142,13 +1142,13 @@ matchOpt option patt = toAlternativeOf $ _matchOpt option patt
 -- | Match a pattern to a subject and lazily return a list of all
 -- non-overlapping portions that matched.
 --
--- @since 1.2.0
+-- @since 1.1.0
 matchAll :: Text -> Text -> [Text]
 matchAll = matchAllOpt mempty
 
 -- | @matchAllOpt mempty = matchAll@
 --
--- @since 1.2.0
+-- @since 1.1.0
 matchAllOpt :: Option -> Text -> Text -> [Text]
 matchAllOpt option patt = toListOf $ _matchOpt option patt
 
@@ -1180,9 +1180,8 @@ subOpt :: Option -> Text -> Text -> Text -> Text
 subOpt option patt replacement = snd . unsafePerformIO . subber where
     subber = unsafePerformIO $ assembleSubber replacement option patt
 
--- | Given a pattern, produce a traversal (0 or more targets) that focuses
--- from a subject to each non-empty list of captures that pattern matches
--- globally.
+-- | Given a pattern, produce a traversal (0 or more targets) that focuses from
+-- a subject to each non-empty list of captures that pattern matches globally.
 --
 -- Substitution works in the following way:  If a capture is set such that the
 -- new `Text` is not equal to the old one, a substitution occurs, otherwise it

--- a/src/hs/Text/Regex/Pcre2/TH.hs
+++ b/src/hs/Text/Regex/Pcre2/TH.hs
@@ -133,7 +133,7 @@ regex = QuasiQuoter {
 
     quoteDec = const $ fail "regex: cannot produce declarations"}
 
--- | A lens variant of `regex`.  Can only be used as an expression.
+-- | A global, optical variant of `regex`.  Can only be used as an expression.
 --
 -- > _regex :: String -> Traversal' Text (Captures info)
 -- > _regex :: String -> Traversal' Text Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.25
+resolver: lts-16.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -28,6 +28,6 @@ packages:
 snapshots:
 - completed:
     size: 533252
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/25.yaml
-    sha256: 147598b98bdd95ec0409bac125a4f1bff3cd4f8d73334d283d098f66a4bcc053
-  original: lts-16.25
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/26.yaml
+    sha256: cdbc5db9c1afe80a5998247939027a0c7db92fa0f20b5cd01596ec3da628b622
+  original: lts-16.26

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -189,6 +189,23 @@ main = hspec $ do
         it "permits other captures to be changed via Traversal'" $ do
             ("" & [_regex|(a)?|] . _capture @0 .~ "foo") `shouldBe` "foo"
 
+    describe "Traversal'" $ do
+        it "supports global substitutions" $ do
+            ("apples and bananas" & _match "a" .~ "o")
+                `shouldBe` "opples ond bononos"
+
+        it "is lazy" $ do
+            counter <- newIORef (0 :: Int)
+            let callout = UnsafeCallout $ \_ -> do
+                    modifyIORef counter (+ 1)
+                    return CalloutProceed
+            take 3 ("apples and bananas" ^.. _matchOpt callout "(?C1)a")
+                `shouldBe` ["a", "a", "a"]
+            readIORef counter `shouldReturn` 3
+
+        it "converges in the presence of empty matches" $ do
+            length (toListOf [_regex||] "12345") `shouldBe` 6
+
     describe "bug fixes" bugFixes
 
 bugFixes :: Spec


### PR DESCRIPTION
Add new functions and rename and change old ones as documented in the
README.
Also bump Stackage LTS to 16.26.

Closes #5.