### PR TITLE
future-proof for simplified subsumption in GHC 9.0

### DIFF
--- a/src/hs/Text/Regex/Pcre2/Internal.hs
+++ b/src/hs/Text/Regex/Pcre2/Internal.hs
@@ -1138,11 +1138,6 @@ getAllSliceRanges matchDataPtr = do
 
     getWhitelistedSliceRanges whitelist matchDataPtr
 
--- | Helper to create non-Template Haskell API functions.  They all take options
--- and a pattern, and then do something via a 'Matcher'.
-newMatcher :: Option -> Text -> Matcher
-newMatcher option patt = unsafePerformIO $ assembleMatcher option patt
-
 -- | Match a pattern to a subject once and return a list of captures, or @[]@ if
 -- no match.
 captures :: Text -> Text -> [Text]
@@ -1189,12 +1184,10 @@ matches = matchesOpt mempty
 
 -- | @matchesOpt mempty = matches@
 matchesOpt :: Option -> Text -> Text -> Bool
-matchesOpt opt t = has $ _capturesInternal
-    matcher
+matchesOpt option patt = has $ _capturesInternal
+    (unsafePerformIO $ assembleMatcher option patt)
     (const $ return noTouchy)
     noTouchy
-  where
-    matcher = newMatcher opt t
 
 -- | Match a pattern to a subject once and return the portion that matched in an
 -- `Alternative`, or `empty` if no match.
@@ -1288,9 +1281,9 @@ _captures = _capturesOpt mempty
 
 -- | @_capturesOpt mempty = _captures@
 _capturesOpt :: Option -> Text -> Traversal' Text (NonEmpty Text)
-_capturesOpt opt t = _capturesInternal matcher getAllSliceRanges slice
-  where
-    matcher = newMatcher opt t
+_capturesOpt option patt = _capturesInternal matcher getAllSliceRanges slice
+    where
+    matcher = unsafePerformIO $ assembleMatcher option patt
 
 -- | Given a pattern, produce a traversal (0 or more targets) that focuses from
 -- a subject to the portions of it that match.
@@ -1301,9 +1294,9 @@ _match = _matchOpt mempty
 
 -- | @_matchOpt mempty = _match@
 _matchOpt :: Option -> Text -> Traversal' Text Text
-_matchOpt opt t = _capturesInternal matcher get0thSliceRanges slice . _headNE
-  where
-    matcher = newMatcher opt t
+_matchOpt option patt = _capturesInternal matcher get0thSliceRanges slice . _headNE
+    where
+    matcher = unsafePerformIO $ assembleMatcher option patt
 
 -- * Support for Template Haskell compile-time regex analysis
 

--- a/src/hs/Text/Regex/Pcre2/Internal.hs
+++ b/src/hs/Text/Regex/Pcre2/Internal.hs
@@ -1140,8 +1140,8 @@ getAllSliceRanges matchDataPtr = do
 
 -- | Helper to create non-Template Haskell API functions.  They all take options
 -- and a pattern, and then do something via a 'Matcher'.
-withMatcher :: (Matcher -> a) -> Option -> Text -> a
-withMatcher f option patt = f $ unsafePerformIO $ assembleMatcher option patt
+newMatcher :: Option -> Text -> Matcher
+newMatcher option patt = unsafePerformIO $ assembleMatcher option patt
 
 -- | Match a pattern to a subject once and return a list of captures, or @[]@ if
 -- no match.
@@ -1189,10 +1189,12 @@ matches = matchesOpt mempty
 
 -- | @matchesOpt mempty = matches@
 matchesOpt :: Option -> Text -> Text -> Bool
-matchesOpt = withMatcher $ \matcher -> has $ _capturesInternal
+matchesOpt opt t = has $ _capturesInternal
     matcher
     (const $ return noTouchy)
     noTouchy
+  where
+    matcher = newMatcher opt t
 
 -- | Match a pattern to a subject once and return the portion that matched in an
 -- `Alternative`, or `empty` if no match.
@@ -1286,8 +1288,9 @@ _captures = _capturesOpt mempty
 
 -- | @_capturesOpt mempty = _captures@
 _capturesOpt :: Option -> Text -> Traversal' Text (NonEmpty Text)
-_capturesOpt = withMatcher $ \matcher ->
-    _capturesInternal matcher getAllSliceRanges slice
+_capturesOpt opt t = _capturesInternal matcher getAllSliceRanges slice
+  where
+    matcher = newMatcher opt t
 
 -- | Given a pattern, produce a traversal (0 or more targets) that focuses from
 -- a subject to the portions of it that match.
@@ -1298,8 +1301,9 @@ _match = _matchOpt mempty
 
 -- | @_matchOpt mempty = _match@
 _matchOpt :: Option -> Text -> Traversal' Text Text
-_matchOpt = withMatcher $ \matcher ->
-    _capturesInternal matcher get0thSliceRanges slice . _headNE
+_matchOpt opt t = _capturesInternal matcher get0thSliceRanges slice . _headNE
+  where
+    matcher = newMatcher opt t
 
 -- * Support for Template Haskell compile-time regex analysis
 


### PR DESCRIPTION
https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption

Another option would be to eta-expand the `Traversal'`s.

To test with stack, use https://gist.github.com/tfausak/a7ef9af57a9f0c0099f187cd3d920a87

<details>
<summary>
Compiler errors on GHC 9.0 without this change
</summary>

```
src/hs/Text/Regex/Pcre2/Internal.hs:1289:16: error:
    • Couldn't match type: (NonEmpty Text -> f0 (NonEmpty Text))
                           -> Text -> f0 Text
                     with: forall (f :: * -> *).
                           Applicative f =>
                           (NonEmpty Text -> f (NonEmpty Text)) -> Text -> f Text
      Expected: Option -> Text -> Traversal' Text (NonEmpty Text)
        Actual: Option
                -> Text -> (NonEmpty Text -> f0 (NonEmpty Text)) -> Text -> f0 Text
    • In the expression:
        withMatcher
          $ \ matcher -> _capturesInternal matcher getAllSliceRanges slice
      In an equation for ‘_capturesOpt’:
          _capturesOpt
            = withMatcher
                $ \ matcher -> _capturesInternal matcher getAllSliceRanges slice
     |
1289 | _capturesOpt = withMatcher $ \matcher ->
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^...

src/hs/Text/Regex/Pcre2/Internal.hs:1301:13: error:
    • Couldn't match type: (Text -> f1 Text) -> Text -> f1 Text
                     with: forall (f :: * -> *).
                           Applicative f =>
                           (Text -> f Text) -> Text -> f Text
      Expected: Option -> Text -> Traversal' Text Text
        Actual: Option -> Text -> (Text -> f1 Text) -> Text -> f1 Text
    • In the expression:
        withMatcher
          $ \ matcher
              -> _capturesInternal matcher get0thSliceRanges slice . _headNE
      In an equation for ‘_matchOpt’:
          _matchOpt
            = withMatcher
                $ \ matcher
                    -> _capturesInternal matcher get0thSliceRanges slice . _headNE
     |
1301 | _matchOpt = withMatcher $ \matcher ->
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^...
```
</details>
